### PR TITLE
Add displace tag to min level

### DIFF
--- a/src/duct/module/logging.clj
+++ b/src/duct/module/logging.clj
@@ -21,7 +21,7 @@
                            ::timbre/brief (ig/ref ::timbre/brief)}}
    ::timbre/spit
    {:fname (merge/displace "logs/dev.log")}
-   ::timbre/brief {:min-level :report}})
+   ::timbre/brief {:min-level (merge/displace :report)}})
 
 (def ^:private env-configs
   {:production prod-config

--- a/test/duct/module/logging_test.clj
+++ b/test/duct/module/logging_test.clj
@@ -36,4 +36,18 @@
                       :appenders {::timbre/spit  (ig/ref ::timbre/spit)
                                   ::timbre/brief (ig/ref ::timbre/brief)}}
                      ::timbre/spit  {:fname "logs/dev.log"}
-                     ::timbre/brief {:min-level :report}}))))))
+                     ::timbre/brief {:min-level :report}})))))
+
+  (testing "config with min log level and file name"
+    (let [config (assoc base-config
+                        ::core/environment :development
+                        ::timbre/brief {:min-level :info}
+                        ::timbre/spit  {:fname "custom.log"})]
+      (is (= (core/prep config)
+             (merge config
+                    {:duct.logger/timbre
+                     {:level     :debug
+                      :appenders {::timbre/spit  (ig/ref ::timbre/spit)
+                                  ::timbre/brief (ig/ref ::timbre/brief)}}
+                     ::timbre/spit  {:fname "custom.log"}
+                     ::timbre/brief {:min-level :info}}))))))


### PR DESCRIPTION
The displace tag makes it easier to change the `min-level` of the `brief` appender. 